### PR TITLE
Remove the charset in http-equiv metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="ja">
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
The charset in `http-equiv` metadata is the old way to set a character encoding.
In HTML5, the `<meta charset="utf-8">` is used for setting character encoding. ( The`<meta http-equiv="Content-Type" content="text/html; charset=utf-8">` is no longer recommended! )
### References
- [<meta> - HTML | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset)
