### PR TITLE
fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-    - "5.5.0"
-install:
-    npm install
-script:
-    npm run lint
+    - "stable"
+sudo: false
+cache:
+  directories:
+    - node_modules

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint ./src/js/*",
+    "test": "npm run lint",
     "deploy": "gh-pages -d ./src"
   },
   "repository": {


### PR DESCRIPTION
このコードに関するテストはブラウザで動かすことを想定しているので、Node.jsのバージョンに依存することはありません。テスト対象のバージョンは`stable`(現時点では`v6.3.1`)だけで十分だと思います。

`npm install`は自動で行われるので不要です。

Travis CIは自動で`npm run test`を実行してその戻り値を評価します。よって`package.json`中の`script`に`test: npm run lint`を書けば自動でlintを実行し、lintが失敗すればCIが落ちるようになります。

その他の設定についてはhttp://teppeis.hatenablog.com/entry/2015/04/recent-travis-ymlを参照してください。
